### PR TITLE
Add omega and uniqtrade routers and update BM Parts prefix

### DIFF
--- a/backend/app/api/bm_parts.py
+++ b/backend/app/api/bm_parts.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 
 from app.adapters.bm_parts_adapter import BMPartsAdapter
 
-router = APIRouter(prefix="/bm_parts", tags=["BM Parts"])
+router = APIRouter(prefix="/bm-parts", tags=["BM Parts"])
 
 
 class ReservedProductsUUIDRequest(BaseModel):

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 from dotenv import load_dotenv
 from fastapi import FastAPI
 
-from app.api import auth, bm_parts, intercars, asg
+from app.api import asg, auth, bm_parts, intercars, omega, uniqtrade
 
 load_dotenv()
 
@@ -11,6 +11,8 @@ app.include_router(auth.router, prefix="/auth", tags=["Authentication"])
 app.include_router(bm_parts.router)
 app.include_router(intercars.router)
 app.include_router(asg.router)
+app.include_router(omega.router)
+app.include_router(uniqtrade.router)
 
 
 @app.get("/")


### PR DESCRIPTION
## Summary
- import the omega and uniqtrade API modules in the FastAPI app and register their routers
- update the BM Parts API router prefix to kebab-case so it matches the new base path

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbac2cef408333b0d94caac05e83db