### PR TITLE
Refactor BM Parts POST endpoints to use request models

### DIFF
--- a/backend/app/adapters/bm_parts_adapter.py
+++ b/backend/app/adapters/bm_parts_adapter.py
@@ -398,9 +398,9 @@ class BMPartsAdapter:
         endpoint = "/returns/products"
         return await self.fetch(endpoint)
 
-    async def create_return_request(self, params: dict):
+    async def create_return_request(self, data: dict):
         endpoint = "/returns/request"
-        return await self.fetch(endpoint, params=params, method="POST")
+        return await self.fetch(endpoint, data=data, method="POST")
 
     async def get_return_causes(self):
         endpoint = "/returns/causes"
@@ -408,4 +408,5 @@ class BMPartsAdapter:
 
     async def notify_return(self, text: str):
         endpoint = "/returns/notify"
-        return await self.fetch(endpoint, params={"text": text}, method="POST")
+        payload = {"text": text}
+        return await self.fetch(endpoint, data=payload, method="POST")


### PR DESCRIPTION
## Summary
- add dedicated Pydantic request models for BM Parts POST routes and use them when calling the adapter
- ensure BM Parts adapter POST helpers accept JSON payloads for return request and notification endpoints

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cbaedcabf08333983802dd5958f661