### PR TITLE
Add validation for ASG product items

### DIFF
--- a/backend/app/api/asg.py
+++ b/backend/app/api/asg.py
@@ -2,7 +2,7 @@ import logging
 from typing import List, Optional, Union
 
 from fastapi import APIRouter, HTTPException, Query
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, model_validator
 
 from app.adapters.asg_adapter import ASGAdapter, ASGAPIError
 
@@ -23,6 +23,12 @@ class ProductItem(BaseModel):
 
     class Config:
         validate_assignment = True
+
+    @model_validator(mode="after")
+    def validate_id_or_sku(cls, product: "ProductItem") -> "ProductItem":
+        if product.id is None and not (product.sku and product.sku.strip()):
+            raise ValueError("Either 'id' or 'sku' must be provided for a product item.")
+        return product
 
 
 class CreateOrderRequest(BaseModel):

--- a/backend/tests/test_asg_api.py
+++ b/backend/tests/test_asg_api.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.api.asg import router
+
+
+app = FastAPI()
+app.include_router(router)
+
+
+client = TestClient(app)
+
+
+def test_create_order_requires_id_or_sku():
+    response = client.post(
+        "/asg/orders/create",
+        json={"products": [{"quantity": 1}], "test": False},
+    )
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert any(
+        "Either 'id' or 'sku' must be provided for a product item." in error.get("msg", "")
+        for error in detail
+    ), detail


### PR DESCRIPTION
## Summary
- ensure ASG product item validation requires either an id or sku
- provide a clear validation error message for missing identifiers
- add an API test covering the validation failure case

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbb0d63f9c8333b22790a726b255c0