### PR TITLE
Ensure Intercars payloads use aliases

### DIFF
--- a/backend/app/api/intercars.py
+++ b/backend/app/api/intercars.py
@@ -110,7 +110,7 @@ async def authorize(request: AuthRequest):
 @router.post("/inventory/quote")
 async def inventory_quote(request: InventoryQuoteRequest):
     async with IntercarsAdapter() as adapter:
-        lines_data = [line.dict() for line in request.lines]
+        lines_data = [line.model_dump(by_alias=True) for line in request.lines]
         return await handle_api_errors(adapter.inventory_quote, lines_data)
 
 
@@ -246,5 +246,5 @@ async def get_customer_finances():
 @router.post("/pricing/quote")
 async def calculate_item_price(request: CalculateItemPriceRequest):
     async with IntercarsAdapter() as adapter:
-        lines_data = [line.dict() for line in request.lines]
+        lines_data = [line.model_dump(by_alias=True) for line in request.lines]
         return await handle_api_errors(adapter.calculate_item_price, lines_data)

--- a/backend/tests/test_intercars_api.py
+++ b/backend/tests/test_intercars_api.py
@@ -1,0 +1,51 @@
+import sys
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.api.intercars import router  # noqa: E402
+
+
+class DummyIntercarsAdapter:
+    last_payload = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def submit_requisition(self, payload):
+        type(self).last_payload = payload
+        return {"status": "ok"}
+
+
+def test_submit_requisition_accepts_camel_case(monkeypatch):
+    app = FastAPI()
+    app.include_router(router)
+
+    client = TestClient(app)
+
+    monkeypatch.setattr(
+        "app.api.intercars.IntercarsAdapter", DummyIntercarsAdapter
+    )
+
+    payload = {
+        "lines": [
+            {
+                "sku": "ABC123",
+                "requiredQuantity": 2,
+                "unitPriceNet": 10.5,
+                "unitPriceGross": 12.6,
+            }
+        ],
+        "customNumber": "CUST-1",
+    }
+
+    response = client.post("/intercars/sales/requisition", json=payload)
+
+    assert response.status_code == 200
+    assert DummyIntercarsAdapter.last_payload == payload


### PR DESCRIPTION
## Summary
- serialize Intercars inventory quote and pricing lines with model_dump(by_alias=True)
- add a regression test confirming the sales requisition endpoint accepts camelCase payloads

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68cbb1b7b0608333beab0f140334685a