### PR TITLE
Fix io import in uniqtrade API

### DIFF
--- a/backend/app/api/uniqtrade.py
+++ b/backend/app/api/uniqtrade.py
@@ -1,5 +1,6 @@
+import io
 import logging
-from typing import Optional, List, Dict, Any, io
+from typing import Optional, List, Dict, Any
 from fastapi import APIRouter, Query, HTTPException
 from pydantic import BaseModel, Field
 from starlette.responses import StreamingResponse


### PR DESCRIPTION
## Summary
- switch uniqtrade API to import io from the standard library rather than typing

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68cbb2d1918083338ae010926fcafcdf