### PR TITLE
Fix uniqtrade search routes

### DIFF
--- a/backend/app/api/uniqtrade.py
+++ b/backend/app/api/uniqtrade.py
@@ -118,7 +118,7 @@ async def handle_api_errors(func, *args, **kwargs):
         }
 
 
-@router.get("/search/products{oem}")
+@router.get("/search/products/{oem}")
 async def search_by_oem(
     oem: str,
     info: Optional[int] = Query(
@@ -170,7 +170,7 @@ async def search_parts(request: SearchRequest):
             )
 
 
-@router.get("/search/products{oem}/brand/{brand}")
+@router.get("/search/products/{oem}/brand/{brand}")
 async def search_by_oem_and_brand(
     oem: str,
     brand: str,


### PR DESCRIPTION
## Summary
- correct the uniqtrade search-by-OEM routes so they include the parameter slashes

## Testing
- not run (pydantic v1 dependency required to import uniqtrade router for schema generation)

------
https://chatgpt.com/codex/tasks/task_e_68cbdf32db408333b3630c6a4f3c35c9