### PR TITLE
Prevent Omega basket zero-count requests

### DIFF
--- a/backend/app/api/omega.py
+++ b/backend/app/api/omega.py
@@ -1,8 +1,8 @@
 import logging
-from typing import List, Optional, Dict, Any
+from typing import List, Optional, Dict, Any, Annotated
 
 from fastapi import APIRouter, HTTPException, Query
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from app.adapters.omega_adapter import OmegaAdapter, OmegaAPIError
 
@@ -17,7 +17,21 @@ class BasketProductItem(BaseModel):
 
 class AddProductRequest(BaseModel):
     product_id: int = Field(..., description="Product ID")
-    count: int = Field(..., description="Product count (can be negative to reduce)")
+    count: Annotated[
+        int,
+        Field(
+            ...,
+            ne=0,
+            description="Product count (non-zero, can be negative to reduce)",
+        ),
+    ]
+
+    @field_validator("count")
+    @classmethod
+    def ensure_non_zero(cls, value: int) -> int:
+        if value == 0:
+            raise ValueError("Product count must be non-zero")
+        return value
 
 
 class AddProductListRequest(BaseModel):

--- a/backend/tests/test_omega_api.py
+++ b/backend/tests/test_omega_api.py
@@ -1,0 +1,44 @@
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.api import omega  # noqa: E402
+
+
+app = FastAPI()
+app.include_router(omega.router)
+
+
+client = TestClient(app)
+
+
+def test_add_product_to_basket_rejects_zero_count(monkeypatch: pytest.MonkeyPatch):
+    call_tracker = {}
+
+    class DummyAdapter:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            call_tracker["entered"] = True
+            return self
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            call_tracker["exited"] = True
+
+        async def add_product_to_basket(self, product_id: int, count: int):
+            call_tracker["called"] = True
+
+    monkeypatch.setattr(omega, "OmegaAdapter", DummyAdapter)
+
+    response = client.post(
+        "/omega/basket/add-product", json={"product_id": 123, "count": 0}
+    )
+
+    assert response.status_code == 422
+    assert "entered" not in call_tracker


### PR DESCRIPTION
## Summary
- prevent zero quantities in `AddProductRequest` by marking the schema as non-zero and validating the value
- cover the validation with a FastAPI router test that ensures Omega is not called for zero-count requests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc06eddea48333b05afdbc8966cb95