### PR TITLE
Add provider registry and central router mounting

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,0 +1,13 @@
+"""API package exports and provider registry."""
+
+from . import asg, bm_parts, intercars, omega, uniqtrade
+
+PROVIDER_REGISTRY = {
+    "bm-parts": bm_parts.router,
+    "intercars": intercars.router,
+    "asg": asg.router,
+    "omega": omega.router,
+    "uniqtrade": uniqtrade.router,
+}
+
+__all__ = ["PROVIDER_REGISTRY"]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,18 +1,16 @@
 from dotenv import load_dotenv
 from fastapi import FastAPI
 
-from app.api import asg, auth, bm_parts, intercars, omega, uniqtrade
+from app.api import PROVIDER_REGISTRY, auth
 
 load_dotenv()
 
 app = FastAPI()
 
 app.include_router(auth.router, prefix="/auth", tags=["Authentication"])
-app.include_router(bm_parts.router)
-app.include_router(intercars.router)
-app.include_router(asg.router)
-app.include_router(omega.router)
-app.include_router(uniqtrade.router)
+
+for _, router in PROVIDER_REGISTRY.items():
+    app.include_router(router)
 
 
 @app.get("/")


### PR DESCRIPTION
## Summary
- create a provider registry that maps provider slugs to their routers
- update FastAPI app startup to mount provider routers using the registry

## Testing
- PYTHONPATH=backend python - <<'PY'
import types, sys
sys.modules['python_multipart'] = types.SimpleNamespace(__version__="1.0.0")

from fastapi.testclient import TestClient
from app.main import app
import app.api.bm_parts as bm_parts_module
import app.api.omega as omega_module


class FakeBMPartsAdapter:
    async def get_profile(self):
        return {"profile": "stub"}


class FakeOmegaAdapter:
    async def __aenter__(self):
        return self

    async def __aexit__(self, exc_type, exc, tb):
        return False

    async def get_basket(self):
        return {"basket": []}


bm_parts_module.BMPartsAdapter = FakeBMPartsAdapter
omega_module.OmegaAdapter = FakeOmegaAdapter

client = TestClient(app)

for method, path in [(client.get, "/bm-parts/profile/me/"), (client.post, "/omega/basket/get")]:
    response = method(path)
    print(path, response.status_code, response.json())
PY

------
https://chatgpt.com/codex/tasks/task_e_68cce437ab1c83338a469b22599f6ed2