### PR TITLE
Refine BM Parts cart payload handling

### DIFF
--- a/backend/app/adapters/bm_parts_adapter.py
+++ b/backend/app/adapters/bm_parts_adapter.py
@@ -17,28 +17,13 @@ class BMPartsAdapter:
         self, endpoint: str, params: dict = None, method: str = "GET", data: dict = None
     ):
         async with httpx.AsyncClient() as client:
-            if method == "GET":
-                response = await client.get(
-                    f"{self.BASE_URL}{endpoint}", params=params, headers=self.headers
-                )
-            elif method == "POST":
-                response = await client.post(
-                    f"{self.BASE_URL}{endpoint}",
-                    json=data,
-                    params=params,
-                    headers=self.headers,
-                )
-            elif method == "PUT":
-                response = await client.put(
-                    f"{self.BASE_URL}{endpoint}",
-                    json=data,
-                    params=params,
-                    headers=self.headers,
-                )
-            elif method == "DELETE":
-                response = await client.delete(
-                    f"{self.BASE_URL}{endpoint}", params=params, headers=self.headers
-                )
+            response = await client.request(
+                method,
+                f"{self.BASE_URL}{endpoint}",
+                params=params,
+                json=data,
+                headers=self.headers,
+            )
 
             response.raise_for_status()
             return response.json()
@@ -265,10 +250,10 @@ class BMPartsAdapter:
         params = {"response_fields": response_fields}
         return await self.fetch(endpoint, params=params)
 
-    async def delete_reserves(self, orders: list):
+    async def delete_reserves(self, orders: list[str]):
         endpoint = "/shopping/reserves"
-        params = {"orders": ",".join(orders)}
-        return await self.fetch(endpoint, method="DELETE", params=params)
+        data = {"orders": orders}
+        return await self.fetch(endpoint, method="DELETE", data=data)
 
     async def get_carts(self):
         endpoint = "/shopping/carts"
@@ -282,18 +267,21 @@ class BMPartsAdapter:
     async def add_product_to_cart(
         self, cart_uuid: str, product_uuid: str, quantity: int
     ):
-        endpoint = f"/shopping/cart/{cart_uuid}/product/{product_uuid}/{quantity}"
-        return await self.fetch(endpoint, method="POST")
+        endpoint = f"/shopping/cart/{cart_uuid}/product"
+        data = {"product_uuid": product_uuid, "quantity": quantity}
+        return await self.fetch(endpoint, method="POST", data=data)
 
     async def update_product_quantity_in_cart(
         self, cart_uuid: str, product_uuid: str, quantity: int
     ):
-        endpoint = f"/shopping/cart/{cart_uuid}/product/{product_uuid}/{quantity}"
-        return await self.fetch(endpoint, method="PUT")
+        endpoint = f"/shopping/cart/{cart_uuid}/product"
+        data = {"product_uuid": product_uuid, "quantity": quantity}
+        return await self.fetch(endpoint, method="PUT", data=data)
 
     async def delete_product_from_cart(self, cart_uuid: str, product_uuid: str):
-        endpoint = f"/shopping/cart/{cart_uuid}/product/{product_uuid}"
-        return await self.fetch(endpoint, method="DELETE")
+        endpoint = f"/shopping/cart/{cart_uuid}/product"
+        data = {"product_uuid": product_uuid}
+        return await self.fetch(endpoint, method="DELETE", data=data)
 
     async def delete_cart(self, cart_uuid: str):
         endpoint = f"/shopping/cart/{cart_uuid}"

--- a/backend/tests/test_bm_parts_api.py
+++ b/backend/tests/test_bm_parts_api.py
@@ -1,0 +1,82 @@
+import sys
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.api.bm_parts import router  # noqa: E402
+
+
+app = FastAPI()
+app.include_router(router)
+
+
+client = TestClient(app)
+
+
+def test_change_product_requires_to_product_uuid():
+    payload = {
+        "cart_uuid": "cart-uuid",
+        "from_product_uuid": "product-a",
+    }
+    response = client.post("/bm-parts/change_product/", json=payload)
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert any(error.get("loc", [])[-1] == "to_product_uuid" for error in detail)
+
+
+def test_add_cart_product_schema_requires_quantity():
+    response = client.post(
+        "/bm-parts/shopping/cart/test-cart/product",
+        json={"product_uuid": "product-uuid"},
+    )
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert any(error.get("loc", [])[-1] == "quantity" for error in detail)
+
+
+def test_delete_reserves_requires_orders_list():
+    response = client.request(
+        "DELETE", "/bm-parts/reserves/", json={"orders": "not-a-list"}
+    )
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert any("orders" in error.get("loc", []) for error in detail)
+
+
+def test_cart_product_openapi_schema_contains_examples():
+    schema = app.openapi()
+    path_item = schema["paths"]["/bm-parts/shopping/cart/{cart_uuid}/product"]
+    schema_ref = path_item["post"]["requestBody"]["content"]["application/json"]["schema"]
+
+    if "$ref" in schema_ref:
+        component_name = schema_ref["$ref"].split("/")[-1]
+        post_schema = schema["components"]["schemas"][component_name]
+    else:
+        post_schema = schema_ref
+
+    assert set(post_schema["required"]) == {"product_uuid", "quantity"}
+    example = post_schema["example"]
+    assert example["quantity"] == 2
+    assert "product_uuid" in example
+
+
+def test_delete_reserves_openapi_schema_contains_example():
+    schema = app.openapi()
+    schema_ref = schema["paths"]["/bm-parts/reserves/"]["delete"]["requestBody"][
+        "content"
+    ]["application/json"]["schema"]
+
+    if "$ref" in schema_ref:
+        component_name = schema_ref["$ref"].split("/")[-1]
+        delete_schema = schema["components"]["schemas"][component_name]
+    else:
+        delete_schema = schema_ref
+
+    assert delete_schema["type"] == "object"
+    assert "orders" in delete_schema["required"]
+    assert isinstance(delete_schema["example"]["orders"], list)


### PR DESCRIPTION
## Summary
- introduce validated Pydantic models with schema examples for BM Parts cart operations and reserves deletion
- update the BM Parts adapter to send JSON payloads for cart modifications and reserve deletions
- add FastAPI schema regression tests covering the updated BM Parts endpoints

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cce66e616c83338736ac3ad3d4358b