### PR TITLE
Add ASG authentication dependency and caching

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,56 @@
+# Backend Authentication Overview
+
+## ASG flow
+
+1. Clients authenticate by sending `POST /asg/login` with a JSON payload that
+   includes `login` and `password`.
+2. The `get_asg_adapter` dependency inspects the incoming request and
+   configures an `ASGAdapter` instance with credentials gathered from:
+   - The `Authorization` header (`Bearer <token>`).
+   - The `X-ASG-Login` and `X-ASG-Password` headers.
+   - The request body (for JSON payloads that contain `login` and `password`).
+3. `ASGAdapter.login()` exchanges the credentials for a bearer token and caches
+   the resulting `CachedCredentialToken` in memory keyed by the credential
+   pair. The cache keeps the token until it expires or a 401 response is
+   received.
+4. Subsequent requests may either reuse the cached token by passing the same
+   credentials (headers or body) or provide the bearer token in the
+   `Authorization` header. When credentials are supplied, the dependency reloads
+   any cached token before the handler executes, avoiding an extra login call.
+5. `POST /asg/refresh` uses the cached credentials to exchange a new access
+   token and updates the cache automatically. Any authenticated data request
+   (for example `POST /asg/me`) will reuse the cached token if available.
+
+### Token persistence hooks
+
+`ASGAdapter` exposes `configure_token_persistence(load_hook=..., save_hook=...)`
+so applications can persist cached tokens outside of process memory (for
+example Redis). Hooks receive/return `CachedCredentialToken` instances and are
+invoked whenever cached data is stored, loaded, or cleared. A simple example:
+
+```python
+from app.adapters.asg_adapter import ASGAdapter, CachedCredentialToken
+
+_storage = {}
+
+
+async def load_token(cache_key: str):
+    raw = _storage.get(cache_key)
+    return CachedCredentialToken.from_payload(raw) if raw else None
+
+
+async def save_token(cache_key: str, token: CachedCredentialToken | None):
+    if token is None:
+        _storage.pop(cache_key, None)
+    else:
+        _storage[cache_key] = token.as_dict()
+
+
+ASGAdapter.configure_token_persistence(
+    load_hook=load_token,
+    save_hook=save_token,
+)
+```
+
+Clearing the persistence hooks or in-memory cache for testing can be done via
+`ASGAdapter.configure_token_persistence()` and `ASGAdapter.clear_token_cache()`.

--- a/backend/app/adapters/asg_adapter.py
+++ b/backend/app/adapters/asg_adapter.py
@@ -1,8 +1,10 @@
 import asyncio
 import hashlib
+import inspect
 import logging
+from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Union
 from urllib.parse import urljoin
 
 import httpx
@@ -10,6 +12,39 @@ import httpx
 from app.config import ASG_TOKEN
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CachedCredentialToken:
+    token: str
+    expires_at: Optional[datetime] = None
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "token": self.token,
+            "expires_at": self.expires_at.isoformat() if self.expires_at else None,
+        }
+
+    @classmethod
+    def from_payload(
+        cls, payload: Optional[Union["CachedCredentialToken", Dict[str, Any]]]
+    ) -> Optional["CachedCredentialToken"]:
+        if payload is None:
+            return None
+        if isinstance(payload, cls):
+            return payload
+        if isinstance(payload, dict):
+            token = payload.get("token")
+            if not token:
+                return None
+            expires_at = payload.get("expires_at")
+            if isinstance(expires_at, str):
+                try:
+                    expires_at = datetime.fromisoformat(expires_at)
+                except ValueError:
+                    expires_at = None
+            return cls(token=token, expires_at=expires_at)
+        return None
 
 
 class ASGAPIError(Exception):
@@ -31,6 +66,15 @@ class ASGAdapter:
     RETRY_BACKOFF = 1.0
     TOKEN_BUFFER_SECONDS = 300
 
+    _token_cache: Dict[str, "CachedCredentialToken"] = {}
+    _cache_lock: asyncio.Lock = asyncio.Lock()
+    _token_load_hook: Optional[
+        Callable[[str], Union["CachedCredentialToken", None, Awaitable[Optional["CachedCredentialToken"]]]]
+    ] = None
+    _token_save_hook: Optional[
+        Callable[[str, Optional["CachedCredentialToken"]], Union[None, Awaitable[None]]]
+    ] = None
+
     def __init__(self, login: str = None, password: str = None, token: str = None):
         self._login = login
         self._password = password
@@ -39,6 +83,7 @@ class ASGAdapter:
         self._client: Optional[httpx.AsyncClient] = None
 
     async def __aenter__(self):
+        await self._load_cached_token()
         self._client = httpx.AsyncClient(
             timeout=httpx.Timeout(self.REQUEST_TIMEOUT),
             limits=httpx.Limits(max_connections=10, max_keepalive_connections=5),
@@ -54,6 +99,13 @@ class ASGAdapter:
         return hashlib.sha256(auth_string.encode()).hexdigest()
 
     @property
+    def _credential_key(self) -> Optional[str]:
+        if not self._login or not self._password:
+            return None
+        raw = f"{self._login}:{self._password}"
+        return hashlib.sha256(raw.encode()).hexdigest()
+
+    @property
     def _is_token_valid(self) -> bool:
         if not self._access_token:
             return False
@@ -63,6 +115,97 @@ class ASGAdapter:
             datetime.utcnow() + timedelta(seconds=self.TOKEN_BUFFER_SECONDS)
             < self._token_expires_at
         )
+
+    @classmethod
+    def clear_token_cache(cls) -> None:
+        cls._token_cache.clear()
+
+    @classmethod
+    def configure_token_persistence(
+        cls,
+        *,
+        load_hook: Optional[Callable[[str], Union["CachedCredentialToken", None, Awaitable[Optional["CachedCredentialToken"]]]]] = None,
+        save_hook: Optional[
+            Callable[[str, Optional["CachedCredentialToken"]], Union[None, Awaitable[None]]]
+        ] = None,
+    ) -> None:
+        cls._token_load_hook = load_hook
+        cls._token_save_hook = save_hook
+
+    async def _invoke_hook(
+        self,
+        hook: Optional[Callable[..., Union[Any, Awaitable[Any]]]],
+        *args: Any,
+    ) -> Optional[Any]:
+        if not hook:
+            return None
+        try:
+            result = hook(*args)
+            if inspect.isawaitable(result):
+                return await result
+            return result
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.warning("Token persistence hook raised an exception: %s", exc)
+            return None
+
+    async def _load_cached_token(self) -> None:
+        if self._access_token:
+            return
+
+        cache_key = self._credential_key
+        if not cache_key:
+            return
+
+        cached: Optional[CachedCredentialToken]
+        async with self._cache_lock:
+            cached = self._token_cache.get(cache_key)
+
+        token_loader = type(self)._token_load_hook
+        if not cached and token_loader:
+            loaded = await self._invoke_hook(token_loader, cache_key)
+            cached = CachedCredentialToken.from_payload(loaded)
+            if cached:
+                async with self._cache_lock:
+                    self._token_cache[cache_key] = cached
+
+        if not cached:
+            return
+
+        if cached.expires_at and cached.expires_at <= datetime.utcnow():
+            await self._clear_cached_token()
+            return
+
+        self._access_token = cached.token
+        self._token_expires_at = cached.expires_at
+
+    async def _store_cached_token(self) -> None:
+        cache_key = self._credential_key
+        if not cache_key or not self._access_token:
+            return
+
+        token_data = CachedCredentialToken(
+            token=self._access_token,
+            expires_at=self._token_expires_at,
+        )
+
+        async with self._cache_lock:
+            self._token_cache[cache_key] = token_data
+
+        await self._invoke_hook(type(self)._token_save_hook, cache_key, token_data)
+
+    async def _clear_cached_token(self) -> None:
+        cache_key = self._credential_key
+
+        self._access_token = None
+        self._token_expires_at = None
+
+        if not cache_key:
+            return
+
+        async with self._cache_lock:
+            self._token_cache.pop(cache_key, None)
+
+        await self._invoke_hook(type(self)._token_save_hook, cache_key, None)
 
     async def _get_client(self) -> httpx.AsyncClient:
         if not self._client:
@@ -89,8 +232,7 @@ class ASGAdapter:
         )
 
         if response.status_code == 401:
-            self._access_token = None
-            self._token_expires_at = None
+            await self._clear_cached_token()
 
         raise ASGAPIError(response.status_code, error_message, error_data)
 
@@ -189,6 +331,7 @@ class ASGAdapter:
         self._token_expires_at = datetime.utcnow() + timedelta(seconds=expires_in)
 
         logger.info("Successfully authenticated with ASG API")
+        await self._store_cached_token()
         return result
 
     async def login(self, login: str, password: str) -> Dict[str, Any]:
@@ -204,13 +347,12 @@ class ASGAdapter:
     async def logout(self) -> Dict[str, Any]:
         try:
             result = await self._make_request("POST", "/auth/logout")
-            self._access_token = None
-            self._token_expires_at = None
-            return result
         except ASGAPIError:
-            self._access_token = None
-            self._token_expires_at = None
+            await self._clear_cached_token()
             raise
+
+        await self._clear_cached_token()
+        return result
 
     async def get_me(self) -> Dict[str, Any]:
         return await self._make_request("POST", "/auth/me")
@@ -223,6 +365,7 @@ class ASGAdapter:
             self._access_token = new_token
             expires_in = result.get("expires_in", 3600)
             self._token_expires_at = datetime.utcnow() + timedelta(seconds=expires_in)
+            await self._store_cached_token()
 
         return result
 

--- a/backend/app/api/asg.py
+++ b/backend/app/api/asg.py
@@ -1,10 +1,11 @@
 import logging
 from typing import List, Optional, Union
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field, model_validator
 
 from app.adapters.asg_adapter import ASGAdapter, ASGAPIError
+from app.dependencies.asg import get_asg_adapter
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/asg", tags=["asg"])
@@ -71,60 +72,62 @@ async def handle_api_errors(func, *args, **kwargs):
 
 
 @router.post("/login")
-async def login(request: LoginRequest):
-    async with ASGAdapter() as adapter:
-        return await handle_api_errors(adapter.login, request.login, request.password)
+async def login(
+    request: LoginRequest,
+    adapter: ASGAdapter = Depends(get_asg_adapter),
+):
+    return await handle_api_errors(adapter.login, request.login, request.password)
 
 
 @router.post("/logout")
-async def logout():
-    async with ASGAdapter() as adapter:
-        return await handle_api_errors(adapter.logout)
+async def logout(adapter: ASGAdapter = Depends(get_asg_adapter)):
+    return await handle_api_errors(adapter.logout)
 
 
 @router.post("/me")
-async def get_me():
-    async with ASGAdapter() as adapter:
-        return await handle_api_errors(adapter.get_me)
+async def get_me(adapter: ASGAdapter = Depends(get_asg_adapter)):
+    return await handle_api_errors(adapter.get_me)
 
 
 @router.post("/refresh")
-async def refresh_token():
-    async with ASGAdapter() as adapter:
-        return await handle_api_errors(adapter.refresh_token)
+async def refresh_token(adapter: ASGAdapter = Depends(get_asg_adapter)):
+    return await handle_api_errors(adapter.refresh_token)
 
 
 @router.post("/orders")
-async def list_orders():
-    async with ASGAdapter() as adapter:
-        return await handle_api_errors(adapter.get_orders)
+async def list_orders(adapter: ASGAdapter = Depends(get_asg_adapter)):
+    return await handle_api_errors(adapter.get_orders)
 
 
 @router.post("/orders/create")
-async def create_order(request: CreateOrderRequest):
-    async with ASGAdapter() as adapter:
-        products_data = [
-            product.dict(exclude_none=True) for product in request.products
-        ]
-        return await handle_api_errors(
-            adapter.create_order, products_data, request.test
-        )
+async def create_order(
+    request: CreateOrderRequest,
+    adapter: ASGAdapter = Depends(get_asg_adapter),
+):
+    products_data = [product.dict(exclude_none=True) for product in request.products]
+    return await handle_api_errors(
+        adapter.create_order, products_data, request.test
+    )
 
 
 @router.post("/orders/{order_id}/cancel")
-async def cancel_order(order_id: Union[int, str]):
+async def cancel_order(
+    order_id: Union[int, str],
+    adapter: ASGAdapter = Depends(get_asg_adapter),
+):
     if not order_id:
         raise HTTPException(status_code=400, detail="Order ID cannot be empty")
 
-    async with ASGAdapter() as adapter:
-        return await handle_api_errors(adapter.cancel_order, order_id)
+    return await handle_api_errors(adapter.cancel_order, order_id)
 
 
 @router.post("/prices")
-async def get_prices(request: GetPricesRequest):
-    async with ASGAdapter() as adapter:
-        filter_dict = request.filter.dict(exclude_none=True) if request.filter else None
-        return await handle_api_errors(adapter.get_prices, filter_dict, request.page)
+async def get_prices(
+    request: GetPricesRequest,
+    adapter: ASGAdapter = Depends(get_asg_adapter),
+):
+    filter_dict = request.filter.dict(exclude_none=True) if request.filter else None
+    return await handle_api_errors(adapter.get_prices, filter_dict, request.page)
 
 
 @router.get("/prices")
@@ -136,6 +139,7 @@ async def get_prices_query(
     min_price: Optional[float] = Query(None, ge=0, description="Minimum price"),
     max_price: Optional[float] = Query(None, ge=0, description="Maximum price"),
     in_stock: Optional[bool] = Query(None, description="Filter by stock availability"),
+    adapter: ASGAdapter = Depends(get_asg_adapter),
 ):
     if max_price is not None and min_price is not None and max_price < min_price:
         raise HTTPException(
@@ -156,28 +160,28 @@ async def get_prices_query(
     if in_stock is not None:
         filters["in_stock"] = in_stock
 
-    async with ASGAdapter() as adapter:
-        return await handle_api_errors(
-            adapter.get_prices, filters if filters else None, page
-        )
+    return await handle_api_errors(
+        adapter.get_prices, filters if filters else None, page
+    )
 
 
 @router.post("/categories")
-async def get_categories():
-    async with ASGAdapter() as adapter:
-        return await handle_api_errors(adapter.get_categories)
+async def get_categories(adapter: ASGAdapter = Depends(get_asg_adapter)):
+    return await handle_api_errors(adapter.get_categories)
 
 
 @router.post("/products/search")
-async def search_products(request: SearchProductsRequest):
-    async with ASGAdapter() as adapter:
-        return await handle_api_errors(
-            adapter.search_products,
-            request.query,
-            request.category_id,
-            request.page,
-            request.per_page,
-        )
+async def search_products(
+    request: SearchProductsRequest,
+    adapter: ASGAdapter = Depends(get_asg_adapter),
+):
+    return await handle_api_errors(
+        adapter.search_products,
+        request.query,
+        request.category_id,
+        request.page,
+        request.per_page,
+    )
 
 
 @router.get("/search/products")
@@ -186,26 +190,30 @@ async def search_products_query(
     category_id: Optional[int] = Query(None, gt=0, description="Category ID filter"),
     page: int = Query(1, ge=1, description="Page number"),
     per_page: int = Query(20, ge=1, le=100, description="Items per page"),
+    adapter: ASGAdapter = Depends(get_asg_adapter),
 ):
-    async with ASGAdapter() as adapter:
-        return await handle_api_errors(
-            adapter.search_products, query, category_id, page, per_page
-        )
+    return await handle_api_errors(
+        adapter.search_products, query, category_id, page, per_page
+    )
 
 
 @router.get("/products/{product_id}")
-async def get_product_details(product_id: Union[int, str]):
+async def get_product_details(
+    product_id: Union[int, str],
+    adapter: ASGAdapter = Depends(get_asg_adapter),
+):
     if not product_id:
         raise HTTPException(status_code=400, detail="Product ID cannot be empty")
 
-    async with ASGAdapter() as adapter:
-        return await handle_api_errors(adapter.get_product_details, product_id)
+    return await handle_api_errors(adapter.get_product_details, product_id)
 
 
 @router.post("/products/{product_id}")
-async def get_product_details_post(product_id: Union[int, str]):
+async def get_product_details_post(
+    product_id: Union[int, str],
+    adapter: ASGAdapter = Depends(get_asg_adapter),
+):
     if not product_id:
         raise HTTPException(status_code=400, detail="Product ID cannot be empty")
 
-    async with ASGAdapter() as adapter:
-        return await handle_api_errors(adapter.get_product_details, product_id)
+    return await handle_api_errors(adapter.get_product_details, product_id)

--- a/backend/app/dependencies/asg.py
+++ b/backend/app/dependencies/asg.py
@@ -1,0 +1,57 @@
+"""FastAPI dependencies related to the ASG integration."""
+
+from __future__ import annotations
+
+from typing import Any, AsyncGenerator, Dict, Optional
+
+from fastapi import Request
+
+from app.adapters.asg_adapter import ASGAdapter
+
+
+def _normalise_value(value: Optional[Any]) -> Optional[str]:
+    if isinstance(value, str):
+        trimmed = value.strip()
+        return trimmed or None
+    return None
+
+
+async def _extract_body_credentials(request: Request) -> Dict[str, Optional[str]]:
+    try:
+        payload = await request.json()
+    except Exception:  # pragma: no cover - body may be empty or malformed
+        return {"login": None, "password": None}
+
+    if not isinstance(payload, dict):
+        return {"login": None, "password": None}
+
+    login = _normalise_value(payload.get("login"))
+    password = _normalise_value(payload.get("password"))
+    return {"login": login, "password": password}
+
+
+async def get_asg_adapter(request: Request) -> AsyncGenerator[ASGAdapter, None]:
+    """Provide a configured :class:`ASGAdapter` for request handlers."""
+
+    login = _normalise_value(request.headers.get("x-asg-login"))
+    password = _normalise_value(request.headers.get("x-asg-password"))
+
+    if not login or not password:
+        body_credentials = await _extract_body_credentials(request)
+        login = login or body_credentials["login"]
+        password = password or body_credentials["password"]
+
+    token: Optional[str] = None
+    auth_header = request.headers.get("authorization")
+    if isinstance(auth_header, str) and auth_header.lower().startswith("bearer "):
+        token = _normalise_value(auth_header.split(" ", 1)[1])
+
+    adapter = ASGAdapter(login=login, password=password, token=token)
+
+    request.state.asg_credentials = {"login": login, "password": password, "token": token}
+
+    async with adapter as session:
+        yield session
+
+
+__all__ = ["get_asg_adapter"]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.adapters.asg_adapter import ASGAdapter
+
+
+@pytest.fixture(autouse=True)
+def reset_asg_adapter_state():
+    ASGAdapter.clear_token_cache()
+    ASGAdapter.configure_token_persistence()
+    yield
+    ASGAdapter.clear_token_cache()
+    ASGAdapter.configure_token_persistence()

--- a/backend/tests/test_asg_api.py
+++ b/backend/tests/test_asg_api.py
@@ -1,23 +1,26 @@
 import sys
 from pathlib import Path
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
+from app.adapters.asg_adapter import ASGAdapter
 from app.api.asg import router
 
 
-app = FastAPI()
-app.include_router(router)
+@pytest.fixture
+def asg_client():
+    app = FastAPI()
+    app.include_router(router)
+    with TestClient(app) as client:
+        yield client
 
 
-client = TestClient(app)
-
-
-def test_create_order_requires_id_or_sku():
-    response = client.post(
+def test_create_order_requires_id_or_sku(asg_client):
+    response = asg_client.post(
         "/asg/orders/create",
         json={"products": [{"quantity": 1}], "test": False},
     )
@@ -28,3 +31,100 @@ def test_create_order_requires_id_or_sku():
         "Either 'id' or 'sku' must be provided for a product item." in error.get("msg", "")
         for error in detail
     ), detail
+def _configure_token_hooks(storage):
+    async def load_hook(cache_key: str):
+        return storage.get(cache_key)
+
+    async def save_hook(cache_key: str, token):
+        if token is None:
+            storage.pop(cache_key, None)
+        else:
+            storage[cache_key] = token
+
+    ASGAdapter.configure_token_persistence(
+        load_hook=load_hook,
+        save_hook=save_hook,
+    )
+
+
+def test_login_persists_token(monkeypatch, asg_client):
+    storage = {}
+    _configure_token_hooks(storage)
+
+    async def fake_make_request(self, method, endpoint, **kwargs):
+        assert endpoint == "/auth/login"
+        assert method == "POST"
+        return {"access_token": "token-login", "expires_in": 3600}
+
+    monkeypatch.setattr(ASGAdapter, "_make_request", fake_make_request)
+
+    response = asg_client.post(
+        "/asg/login", json={"login": "demo", "password": "secret"}
+    )
+
+    assert response.status_code == 200
+    assert response.json()["access_token"] == "token-login"
+
+    adapter = ASGAdapter(login="demo", password="secret")
+    cache_key = adapter._credential_key  # noqa: SLF001 - test helper
+    assert cache_key in storage
+    assert storage[cache_key].token == "token-login"
+
+
+def test_refresh_updates_cached_token(monkeypatch, asg_client):
+    storage = {}
+    _configure_token_hooks(storage)
+
+    async def fake_make_request(self, method, endpoint, **kwargs):
+        if endpoint == "/auth/login":
+            return {"access_token": "token-login", "expires_in": 3600}
+        if endpoint == "/auth/refresh":
+            return {"access_token": "token-refresh", "expires_in": 3600}
+        raise AssertionError(f"Unexpected endpoint {endpoint}")
+
+    monkeypatch.setattr(ASGAdapter, "_make_request", fake_make_request)
+
+    login_payload = {"login": "demo", "password": "secret"}
+    login_response = asg_client.post("/asg/login", json=login_payload)
+    assert login_response.status_code == 200
+
+    refresh_response = asg_client.post(
+        "/asg/refresh",
+        headers={"X-ASG-Login": "demo", "X-ASG-Password": "secret"},
+    )
+
+    assert refresh_response.status_code == 200
+    assert refresh_response.json()["access_token"] == "token-refresh"
+
+    adapter = ASGAdapter(login="demo", password="secret")
+    cache_key = adapter._credential_key  # noqa: SLF001 - test helper
+    assert storage[cache_key].token == "token-refresh"
+
+
+def test_authenticated_call_reuses_cache(monkeypatch, asg_client):
+    storage = {}
+    _configure_token_hooks(storage)
+
+    calls = []
+
+    async def fake_make_request(self, method, endpoint, **kwargs):
+        if endpoint == "/auth/login":
+            calls.append("login")
+            return {"access_token": "token-login", "expires_in": 3600}
+        if endpoint == "/auth/me":
+            calls.append("me")
+            assert self._access_token == "token-login"
+            return {"user": {"id": 1}}
+        raise AssertionError(f"Unexpected endpoint {endpoint}")
+
+    monkeypatch.setattr(ASGAdapter, "_make_request", fake_make_request)
+
+    asg_client.post("/asg/login", json={"login": "demo", "password": "secret"})
+
+    response = asg_client.post(
+        "/asg/me", headers={"X-ASG-Login": "demo", "X-ASG-Password": "secret"}
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"user": {"id": 1}}
+    assert calls == ["login", "me"]


### PR DESCRIPTION
## Summary
- add a FastAPI dependency that extracts ASG credentials or bearer tokens and shares a configured adapter
- extend `ASGAdapter` with per-credential token caching and persistence hooks, and update routes to consume the dependency
- document the authentication flow and cover login, refresh, and authenticated data calls with regression tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdbe4cd31c8333927ac1f87ee5e7a6