### PR TITLE
Disable mutating Omega GET routes by default

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -54,3 +54,16 @@ ASGAdapter.configure_token_persistence(
 
 Clearing the persistence hooks or in-memory cache for testing can be done via
 `ASGAdapter.configure_token_persistence()` and `ASGAdapter.clear_token_cache()`.
+
+## Omega mutating GET routes
+
+Historically the Omega adapter exposed basket, claim, contact, and expense
+mutations as both `POST` and `GET` routes. Those `GET` variants have been
+deprecated and are now disabled by default. Clients should migrate to the
+existing `POST` endpoints, which remain unchanged.
+
+For backwards compatibility you can temporarily re-enable the legacy `GET`
+routes by setting the `ENABLE_MUTATING_GET_ROUTES` environment variable to a
+truthy value (for example `1` or `true`) before starting the service. When
+enabled, the routes are still marked as deprecated in the OpenAPI schema to
+discourage new integrations from relying on them.

--- a/backend/app/api/omega.py
+++ b/backend/app/api/omega.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field, field_validator
 
 from app.adapters.omega_adapter import OmegaAdapter, OmegaAPIError
+from app.config import ENABLE_MUTATING_GET_ROUTES
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/omega", tags=["omega"])
@@ -557,93 +558,108 @@ async def get_expense_document_details(request: GetExpenseDocumentDetailsRequest
         )
 
 
-@router.get("/basket/add-product")
-async def add_product_to_basket_query(
-    product_id: int = Query(..., description="Product ID"),
-    count: int = Query(..., gt=0, description="Product count must be positive"),
-):
-    async with OmegaAdapter() as adapter:
-        return await handle_api_errors(adapter.add_product_to_basket, product_id, count)
+if ENABLE_MUTATING_GET_ROUTES:
+    @router.get("/basket/add-product", deprecated=True)
+    async def add_product_to_basket_query(
+        product_id: int = Query(..., description="Product ID"),
+        count: int = Query(..., gt=0, description="Product count must be positive"),
+    ):
+        async with OmegaAdapter() as adapter:
+            return await handle_api_errors(
+                adapter.add_product_to_basket, product_id, count
+            )
 
 
-@router.get("/basket/remove-product")
-async def remove_product_from_basket_query(
-    product_id: int = Query(..., description="Product ID to remove"),
-):
-    async with OmegaAdapter() as adapter:
-        return await handle_api_errors(adapter.remove_product_from_basket, product_id)
+    @router.get("/basket/remove-product", deprecated=True)
+    async def remove_product_from_basket_query(
+        product_id: int = Query(..., description="Product ID to remove"),
+    ):
+        async with OmegaAdapter() as adapter:
+            return await handle_api_errors(
+                adapter.remove_product_from_basket, product_id
+            )
 
 
-@router.get("/claims/kind-claims")
-async def get_kind_claims_query(
-    product_id: str = Query(..., description="Product ID"),
-    doc_id: str = Query(..., description="Document ID"),
-):
-    async with OmegaAdapter() as adapter:
-        return await handle_api_errors(adapter.get_kind_claims, product_id, doc_id)
+    @router.get("/claims/kind-claims", deprecated=True)
+    async def get_kind_claims_query(
+        product_id: str = Query(..., description="Product ID"),
+        doc_id: str = Query(..., description="Document ID"),
+    ):
+        async with OmegaAdapter() as adapter:
+            return await handle_api_errors(
+                adapter.get_kind_claims, product_id, doc_id
+            )
 
 
-@router.get("/claims/discount")
-async def get_discount_query(
-    product_id: str = Query(..., description="Product ID"),
-    doc_id: str = Query(..., description="Document ID"),
-    type_id: str = Query(..., description="Type ID"),
-):
-    async with OmegaAdapter() as adapter:
-        return await handle_api_errors(
-            adapter.get_discount, product_id, doc_id, type_id
-        )
+    @router.get("/claims/discount", deprecated=True)
+    async def get_discount_query(
+        product_id: str = Query(..., description="Product ID"),
+        doc_id: str = Query(..., description="Document ID"),
+        type_id: str = Query(..., description="Type ID"),
+    ):
+        async with OmegaAdapter() as adapter:
+            return await handle_api_errors(
+                adapter.get_discount, product_id, doc_id, type_id
+            )
 
 
-@router.get("/claims/addresses")
-async def get_addresses_query(
-    kind: int = Query(..., description="Address kind"),
-):
-    async with OmegaAdapter() as adapter:
-        return await handle_api_errors(adapter.get_addresses, kind)
+    @router.get("/claims/addresses", deprecated=True)
+    async def get_addresses_query(
+        kind: int = Query(..., description="Address kind"),
+    ):
+        async with OmegaAdapter() as adapter:
+            return await handle_api_errors(adapter.get_addresses, kind)
 
 
-@router.get("/contact/get-contacts")
-async def get_contact_list_query(
-    customer_id: str = Query(..., description="Customer ID"),
-):
-    async with OmegaAdapter() as adapter:
-        return await handle_api_errors(adapter.get_contact_list, customer_id)
+    @router.get("/contact/get-contacts", deprecated=True)
+    async def get_contact_list_query(
+        customer_id: str = Query(..., description="Customer ID"),
+    ):
+        async with OmegaAdapter() as adapter:
+            return await handle_api_errors(
+                adapter.get_contact_list, customer_id
+            )
 
 
-@router.get("/contact/get-contact-details")
-async def get_contact_details_query(
-    contact_id: str = Query(..., description="Contact ID"),
-):
-    async with OmegaAdapter() as adapter:
-        return await handle_api_errors(adapter.get_contact_details, contact_id)
+    @router.get("/contact/get-contact-details", deprecated=True)
+    async def get_contact_details_query(
+        contact_id: str = Query(..., description="Contact ID"),
+    ):
+        async with OmegaAdapter() as adapter:
+            return await handle_api_errors(
+                adapter.get_contact_details, contact_id
+            )
 
 
-@router.get("/expense/get-expense-document")
-async def get_expense_document_query(
-    doc_id: str = Query(..., description="Document ID"),
-):
-    async with OmegaAdapter() as adapter:
-        return await handle_api_errors(adapter.get_expense_document, doc_id)
+    @router.get("/expense/get-expense-document", deprecated=True)
+    async def get_expense_document_query(
+        doc_id: str = Query(..., description="Document ID"),
+    ):
+        async with OmegaAdapter() as adapter:
+            return await handle_api_errors(
+                adapter.get_expense_document, doc_id
+            )
 
 
-@router.get("/expense/get-expense-document-list")
-async def get_expense_document_list_query(
-    start_date: str = Query(..., description="Start date in DD.MM.YYYY format"),
-    end_date: str = Query(..., description="End date in DD.MM.YYYY format"),
-):
-    async with OmegaAdapter() as adapter:
-        return await handle_api_errors(
-            adapter.get_expense_document_list, start_date, end_date
-        )
+    @router.get("/expense/get-expense-document-list", deprecated=True)
+    async def get_expense_document_list_query(
+        start_date: str = Query(..., description="Start date in DD.MM.YYYY format"),
+        end_date: str = Query(..., description="End date in DD.MM.YYYY format"),
+    ):
+        async with OmegaAdapter() as adapter:
+            return await handle_api_errors(
+                adapter.get_expense_document_list, start_date, end_date
+            )
 
 
-@router.get("/expense/get-expense-document-details")
-async def get_expense_document_details_query(
-    doc_id: str = Query(..., description="Document ID"),
-):
-    async with OmegaAdapter() as adapter:
-        return await handle_api_errors(adapter.get_expense_document_details, doc_id)
+    @router.get("/expense/get-expense-document-details", deprecated=True)
+    async def get_expense_document_details_query(
+        doc_id: str = Query(..., description="Document ID"),
+    ):
+        async with OmegaAdapter() as adapter:
+            return await handle_api_errors(
+                adapter.get_expense_document_details, doc_id
+            )
 
 
 @router.post("/invoice/add")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -3,6 +3,14 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+
+def _get_bool_env(var_name: str, default: bool) -> bool:
+    value = os.getenv(var_name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
 SUPABASE_URL = os.getenv("SUPABASE_URL")
 SUPABASE_KEY = os.getenv("SUPABASE_KEY")
 BM_PARTS_TOKEN = os.getenv("BM_PARTS_TOKEN")
@@ -13,3 +21,5 @@ UNIQTRADE_PASSWORD = os.getenv("UNIQTRADE_PASSWORD")
 UNIQTRADE_FINGERPRINT = os.getenv("UNIQTRADE_FINGERPRINT")
 INTERCARS_CLIENT_ID = os.getenv("INTERCARS_CLIENT_ID")
 INTERCARS_CLIENT_SECRET = os.getenv("INTERCARS_CLIENT_SECRET")
+
+ENABLE_MUTATING_GET_ROUTES = _get_bool_env("ENABLE_MUTATING_GET_ROUTES", False)

--- a/backend/tests/test_omega_api.py
+++ b/backend/tests/test_omega_api.py
@@ -1,9 +1,11 @@
+import importlib
 import sys
 from pathlib import Path
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from fastapi.routing import APIRoute
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -15,6 +17,36 @@ app.include_router(omega.router)
 
 
 client = TestClient(app)
+
+
+MUTATING_GET_ROUTES = {
+    "/omega/basket/add-product",
+    "/omega/basket/remove-product",
+    "/omega/claims/kind-claims",
+    "/omega/claims/discount",
+    "/omega/claims/addresses",
+    "/omega/contact/get-contacts",
+    "/omega/contact/get-contact-details",
+    "/omega/expense/get-expense-document",
+    "/omega/expense/get-expense-document-list",
+    "/omega/expense/get-expense-document-details",
+}
+
+
+def _load_omega_router(monkeypatch: pytest.MonkeyPatch, flag_value: str | None) -> FastAPI:
+    if flag_value is None:
+        monkeypatch.delenv("ENABLE_MUTATING_GET_ROUTES", raising=False)
+    else:
+        monkeypatch.setenv("ENABLE_MUTATING_GET_ROUTES", flag_value)
+
+    config_module = importlib.import_module("app.config")
+    omega_module = importlib.import_module("app.api.omega")
+    importlib.reload(config_module)
+    importlib.reload(omega_module)
+
+    test_app = FastAPI()
+    test_app.include_router(omega_module.router)
+    return test_app
 
 
 def test_add_product_to_basket_rejects_zero_count(monkeypatch: pytest.MonkeyPatch):
@@ -42,3 +74,38 @@ def test_add_product_to_basket_rejects_zero_count(monkeypatch: pytest.MonkeyPatc
 
     assert response.status_code == 422
     assert "entered" not in call_tracker
+
+
+def test_mutating_get_routes_disabled_by_default(monkeypatch: pytest.MonkeyPatch):
+    test_app = _load_omega_router(monkeypatch, None)
+
+    get_routes = {
+        route.path
+        for route in test_app.router.routes
+        if isinstance(route, APIRoute) and "GET" in route.methods
+    }
+
+    assert MUTATING_GET_ROUTES.isdisjoint(get_routes)
+
+
+def test_mutating_get_routes_can_be_reenabled(monkeypatch: pytest.MonkeyPatch):
+    test_app = _load_omega_router(monkeypatch, "true")
+
+    get_routes = {
+        route.path
+        for route in test_app.router.routes
+        if isinstance(route, APIRoute) and "GET" in route.methods
+    }
+
+    assert MUTATING_GET_ROUTES.issubset(get_routes)
+
+    for route in test_app.router.routes:
+        if (
+            isinstance(route, APIRoute)
+            and route.path in MUTATING_GET_ROUTES
+            and "GET" in route.methods
+        ):
+            assert route.deprecated is True
+
+    # Reset modules back to the default state to avoid side effects on other tests
+    _load_omega_router(monkeypatch, None)


### PR DESCRIPTION
## Summary
- gate Omega's legacy mutating GET routes behind the new ENABLE_MUTATING_GET_ROUTES flag and mark them deprecated when enabled
- document the feature flag so API consumers switch to the supported POST endpoints
- add regression tests to confirm the GET routes are disabled by default and only reappear when explicitly enabled

## Testing
- pytest tests/test_omega_api.py


------
https://chatgpt.com/codex/tasks/task_e_68cdc16b45fc83338edc7182c3a27775