### PR TITLE
Use shared async Supabase client in auth

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,20 +1,36 @@
-import requests
-from fastapi import APIRouter, Header, HTTPException, Depends
+from __future__ import annotations
+
+import httpx
+from fastapi import APIRouter, Depends, Header, HTTPException
 
 from app.config import SUPABASE_URL
+from app.dependencies.supabase import get_supabase_client
 
 router = APIRouter()
 
 
-def get_current_user(authorization: str = Header(None)):
+async def get_current_user(
+    authorization: str = Header(None),
+    client: httpx.AsyncClient = Depends(get_supabase_client),
+):
     """Validate JWT Token with Supabase."""
     if not authorization or not authorization.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Invalid Authorization Header")
 
-    token = authorization.split("Bearer ")[1]
-    response = requests.get(
-        f"{SUPABASE_URL}/auth/v1/user", headers={"Authorization": f"Bearer {token}"}
-    )
+    if not SUPABASE_URL:
+        raise HTTPException(status_code=500, detail="Supabase URL is not configured")
+
+    token = authorization.split("Bearer ", 1)[1].strip()
+    if not token:
+        raise HTTPException(status_code=401, detail="Invalid Authorization Header")
+
+    try:
+        response = await client.get(
+            f"{SUPABASE_URL}/auth/v1/user",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    except httpx.RequestError as exc:  # pragma: no cover - network failure
+        raise HTTPException(status_code=503, detail="Unable to reach Supabase") from exc
 
     if response.status_code != 200:
         raise HTTPException(status_code=401, detail="Invalid Token")

--- a/backend/app/dependencies/supabase.py
+++ b/backend/app/dependencies/supabase.py
@@ -1,0 +1,26 @@
+"""Supabase-specific FastAPI dependencies."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import httpx
+
+SUPABASE_TIMEOUT = httpx.Timeout(10.0)
+_supabase_client: Optional[httpx.AsyncClient] = None
+
+
+def _create_client() -> httpx.AsyncClient:
+    return httpx.AsyncClient(timeout=SUPABASE_TIMEOUT)
+
+
+async def get_supabase_client() -> httpx.AsyncClient:
+    """Return a shared :class:`httpx.AsyncClient` instance for Supabase calls."""
+
+    global _supabase_client
+    if _supabase_client is None:
+        _supabase_client = _create_client()
+    return _supabase_client
+
+
+__all__ = ["get_supabase_client", "SUPABASE_TIMEOUT"]

--- a/backend/tests/test_auth_api.py
+++ b/backend/tests/test_auth_api.py
@@ -1,0 +1,91 @@
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import app.api.auth as auth_module
+from app.api.auth import router
+from app.dependencies.supabase import get_supabase_client
+
+
+class DummyResponse:
+    def __init__(self, status_code: int, payload: Dict[str, Any]):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> Dict[str, Any]:
+        return self._payload
+
+
+class DummySupabaseClient:
+    def __init__(self, response: DummyResponse):
+        self._response = response
+        self.requests = []
+
+    async def get(self, url: str, *, headers: Dict[str, str]):
+        self.requests.append((url, headers))
+        return self._response
+
+
+@pytest.fixture
+def auth_app(monkeypatch):
+    app = FastAPI()
+    app.include_router(router, prefix="/auth")
+
+    monkeypatch.setattr(auth_module, "SUPABASE_URL", "https://supabase.test")
+
+    yield app
+
+
+def test_auth_me_returns_user(auth_app):
+    dummy_response = DummyResponse(200, {"id": "user-123"})
+    dummy_client = DummySupabaseClient(dummy_response)
+
+    async def override_client():
+        return dummy_client
+
+    auth_app.dependency_overrides[get_supabase_client] = override_client
+
+    with TestClient(auth_app) as client:
+        response = client.get(
+            "/auth/me",
+            headers={"Authorization": "Bearer demo-token"},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"id": "user-123"}
+    assert dummy_client.requests == [
+        ("https://supabase.test/auth/v1/user", {"Authorization": "Bearer demo-token"})
+    ]
+
+
+def test_auth_me_invalid_token(auth_app):
+    dummy_response = DummyResponse(401, {"message": "invalid"})
+    dummy_client = DummySupabaseClient(dummy_response)
+
+    async def override_client():
+        return dummy_client
+
+    auth_app.dependency_overrides[get_supabase_client] = override_client
+
+    with TestClient(auth_app) as client:
+        response = client.get(
+            "/auth/me",
+            headers={"Authorization": "Bearer expired-token"},
+        )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Invalid Token"}
+
+
+def test_auth_me_missing_authorization_header(auth_app):
+    with TestClient(auth_app) as client:
+        response = client.get("/auth/me")
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Invalid Authorization Header"}


### PR DESCRIPTION
## Summary
- switch the auth dependency to an async helper that reuses a shared httpx.AsyncClient with a timeout when contacting Supabase
- update the /auth/me route to await the async dependency and improve validation around the Authorization header
- add tests that cover successful and failed /auth/me responses when Supabase accepts or rejects the token

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdc4a96fe88333bc929ce852bdc56e