### PR TITLE
Add adapter abstraction and aggregated search endpoint

### DIFF
--- a/backend/app/adapters/__init__.py
+++ b/backend/app/adapters/__init__.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from app.adapters.base import BaseAdapter
+from app.adapters.bm_parts_adapter import BMPartsAdapter
+
+adapter_registry: Dict[str, BaseAdapter] = {
+    "bmparts": BMPartsAdapter(),
+}
+
+__all__ = ["adapter_registry", "BaseAdapter", "BMPartsAdapter"]

--- a/backend/app/adapters/base.py
+++ b/backend/app/adapters/base.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import requests
+
+
+class AdapterError(Exception):
+    """Base exception for adapter-related failures."""
+
+
+@dataclass
+class RequestContext:
+    """Represents metadata required to execute an HTTP request."""
+
+    method: str
+    url: str
+    headers: Dict[str, str]
+    params: Optional[Dict[str, Any]] = None
+    json: Optional[Dict[str, Any]] = None
+    data: Optional[Any] = None
+    timeout: Optional[float] = None
+
+
+class BaseAdapter:
+    """Shared abstraction for adapters that communicate with external APIs."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        default_headers: Optional[Dict[str, str]] = None,
+        timeout: Optional[float] = None,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.default_headers = default_headers or {}
+        self.timeout = timeout
+
+    def build_url(self, path: str = "") -> str:
+        """Create a fully qualified URL using the adapter base URL."""
+
+        if not path:
+            return self.base_url
+        return f"{self.base_url}/{path.lstrip('/')}"
+
+    def prepare_request(
+        self,
+        method: str,
+        *,
+        path: str = "",
+        headers: Optional[Dict[str, str]] = None,
+        params: Optional[Dict[str, Any]] = None,
+        json: Optional[Dict[str, Any]] = None,
+        data: Optional[Any] = None,
+        timeout: Optional[float] = None,
+    ) -> RequestContext:
+        """Compose a :class:`RequestContext` with merged headers."""
+
+        merged_headers = {**self.default_headers, **(headers or {})}
+        return RequestContext(
+            method=method,
+            url=self.build_url(path),
+            headers=merged_headers,
+            params=params,
+            json=json,
+            data=data,
+            timeout=timeout or self.timeout,
+        )
+
+    def request(self, context: RequestContext) -> requests.Response:
+        """Execute an HTTP request and surface consistent adapter errors."""
+
+        try:
+            response = requests.request(
+                context.method,
+                context.url,
+                headers=context.headers,
+                params=context.params,
+                json=context.json,
+                data=context.data,
+                timeout=context.timeout,
+            )
+            response.raise_for_status()
+            return response
+        except requests.RequestException as exc:  # pragma: no cover - thin wrapper
+            raise AdapterError(str(exc)) from exc
+
+    def search(self, query: str, **_: Any) -> Dict[str, Any]:
+        """Search the provider for the given query.
+
+        Subclasses must override this method to implement provider-specific
+        behavior.
+        """
+
+        raise NotImplementedError

--- a/backend/app/adapters/bm_parts_adapter.py
+++ b/backend/app/adapters/bm_parts_adapter.py
@@ -1,11 +1,43 @@
-import requests
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from app.adapters.base import AdapterError, BaseAdapter
+from app.config import BMPARTS_API_KEY, BMPARTS_BASE_URL
 
 
-class BMPartsAdapter:
-    API_URL = ""
+class BMPartsAdapter(BaseAdapter):
+    """Adapter responsible for communicating with the BM Parts API."""
 
-    def fetch_data(self):
-        response = requests.get(self.API_URL)
-        if response.status_code == 200:
+    def __init__(self, *, base_url: Optional[str] = None, api_key: Optional[str] = None) -> None:
+        headers: Dict[str, str] = {}
+        resolved_api_key = api_key or BMPARTS_API_KEY
+        if resolved_api_key:
+            headers["Authorization"] = f"Bearer {resolved_api_key}"
+
+        super().__init__(
+            base_url=base_url or BMPARTS_BASE_URL or "",
+            default_headers=headers,
+        )
+
+    def fetch_data(self, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """Retrieve a generic payload from the provider."""
+
+        if not self.base_url:
+            return {"error": "BM Parts base URL is not configured"}
+
+        context = self.prepare_request("GET", params=params)
+        try:
+            response = self.request(context)
             return response.json()
-        return {"error": "Failed to fetch data"}
+        except AdapterError as exc:
+            return {"error": "Failed to fetch data", "details": str(exc)}
+
+    def search(self, query: str, **kwargs: Any) -> Dict[str, Any]:  # type: ignore[override]
+        """Execute a search request against the BM Parts API."""
+
+        params: Dict[str, Any] = kwargs.get("params", {}).copy()
+        if query:
+            params.setdefault("q", query)
+
+        return self.fetch_data(params=params)

--- a/backend/app/api/general_adapter.py
+++ b/backend/app/api/general_adapter.py
@@ -1,13 +1,79 @@
-from fastapi import APIRouter, Depends
-from app.adapters.bm_parts_adapter import BMPartsAdapter
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.concurrency import run_in_threadpool
+from pydantic import BaseModel, Field
+
+from app.adapters import adapter_registry
+from app.adapters.base import AdapterError
 from app.api.auth import get_current_user
 
 router = APIRouter()
 
-bm_parts_adapter = BMPartsAdapter()
+
+class AggregatedSearchRequest(BaseModel):
+    """Describe the payload for aggregated adapter searches."""
+
+    query: str = Field("", description="Search query forwarded to each provider")
+    providers: List[str] = Field(
+        default_factory=list,
+        description="Optional list of provider identifiers. If omitted, all providers are used.",
+    )
+    provider_params: Dict[str, Dict[str, Any]] = Field(
+        default_factory=dict,
+        description="Optional dictionary of per-provider parameter overrides.",
+    )
 
 
 @router.get("/bmparts/data")
-async def get_bm_parts_data(user: dict = Depends(get_current_user)):
-    """Fetch data from BM Parts (Requires Authentication)"""
-    return bm_parts_adapter.fetch_data()
+async def get_bm_parts_data(user: dict = Depends(get_current_user)) -> Dict[str, Any]:
+    """Fetch data from BM Parts (Requires Authentication)."""
+
+    adapter = adapter_registry["bmparts"]
+    return adapter.fetch_data()
+
+
+@router.post("/search", status_code=status.HTTP_200_OK)
+async def aggregated_search(
+    request: AggregatedSearchRequest,
+    user: dict = Depends(get_current_user),
+) -> Dict[str, Any]:
+    """Fan out the search request to all requested providers."""
+
+    del user  # Authentication handled via dependency; suppress unused variable lint.
+
+    if not adapter_registry:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="No providers configured")
+
+    requested_providers = request.providers or list(adapter_registry.keys())
+
+    missing = [name for name in requested_providers if name not in adapter_registry]
+    if missing:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"message": "Unknown providers requested", "providers": missing},
+        )
+
+    async def dispatch(provider_name: str) -> Dict[str, Any]:
+        adapter = adapter_registry[provider_name]
+        params = request.provider_params.get(provider_name, {})
+        try:
+            result = await run_in_threadpool(adapter.search, request.query, **params)
+            return {"provider": provider_name, "data": result}
+        except AdapterError as exc:
+            return {"provider": provider_name, "error": str(exc)}
+
+    responses = await asyncio.gather(*(dispatch(name) for name in requested_providers))
+
+    aggregated: Dict[str, Any] = {}
+    for entry in responses:
+        provider_name = entry["provider"]
+        if "data" in entry:
+            aggregated[provider_name] = entry["data"]
+        else:
+            aggregated[provider_name] = {"error": entry.get("error", "Unknown error")}
+
+    return {"results": aggregated}

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -5,3 +5,6 @@ load_dotenv()
 
 SUPABASE_URL = os.getenv("SUPABASE_URL")
 SUPABASE_KEY = os.getenv("SUPABASE_KEY")
+
+BMPARTS_BASE_URL = os.getenv("BMPARTS_BASE_URL", "")
+BMPARTS_API_KEY = os.getenv("BMPARTS_API_KEY")

--- a/backend/docs/README.md
+++ b/backend/docs/README.md
@@ -1,0 +1,39 @@
+# Adapter Architecture
+
+This project now exposes a shared abstraction for third-party parts providers. The key elements are:
+
+- `app.adapters.base.BaseAdapter` centralizes HTTP handling, default headers, and error propagation for provider implementations.
+- Each provider-specific adapter (for example, `BMPartsAdapter`) inherits from the base class, configures its authentication headers, and implements any search/fetch helpers it requires.
+- `app.adapters.adapter_registry` maintains the set of initialized adapters that the API layer can query.
+
+## Environment variables
+
+Configure the BM Parts adapter with the following variables in your environment or `.env` file:
+
+| Variable | Description |
+| --- | --- |
+| `BMPARTS_BASE_URL` | Base URL for the BM Parts API. |
+| `BMPARTS_API_KEY` | Bearer token used to authenticate requests. |
+
+## API endpoints
+
+| Method | Endpoint | Description |
+| --- | --- | --- |
+| `GET` | `/api/bmparts/data` | Returns the default BM Parts payload using the shared adapter abstraction. |
+| `POST` | `/api/search` | Accepts a list of providers and fans the request out to each adapter, aggregating the results. |
+
+### Aggregated search payload
+
+```json
+{
+  "query": "alternator",
+  "providers": ["bmparts"],
+  "provider_params": {
+    "bmparts": {
+      "params": {"category": "electrical"}
+    }
+  }
+}
+```
+
+When `providers` is omitted, all configured adapters are queried. Per-provider overrides allow the frontend to add query-string parameters or JSON bodies required by each provider.


### PR DESCRIPTION
## Summary
- add a reusable BaseAdapter with centralized request handling for external providers
- update the BM Parts adapter to use the shared base class and configurable auth headers
- register adapters for lookup, expose a new aggregated search route, and document the workflow in backend/docs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdd5e0b6488333baf6e425232169dd