### PR TITLE
feat: add aggregated search fan-out route

### DIFF
--- a/backend/app/adapters/base.py
+++ b/backend/app/adapters/base.py
@@ -1,0 +1,147 @@
+"""Shared abstractions for talking to external provider APIs."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, Optional, Type
+from urllib.parse import urljoin
+
+import httpx
+from fastapi import HTTPException
+
+
+class ExternalAPIError(HTTPException):
+    """Base error raised when an upstream provider call fails."""
+
+    provider: str
+
+    def __init__(
+        self,
+        provider: str,
+        *,
+        status_code: int,
+        detail: Any | None = None,
+        message: str | None = None,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> None:
+        fallback_message = message or f"{provider} API request failed"
+        detail_payload = detail if detail is not None else {"message": fallback_message}
+        super().__init__(status_code=status_code, detail=detail_payload, headers=headers)
+        self.provider = provider
+        self.message = fallback_message
+
+
+class ExternalAPIAdapter:
+    """Helper that wraps common HTTP client behaviour for adapters."""
+
+    BASE_URL = ""
+    REQUEST_TIMEOUT = 30.0
+    MAX_RETRIES = 3
+    RETRY_BACKOFF = 1.0
+    PROVIDER_NAME = "External"
+    ERROR_CLS: Type[ExternalAPIError] = ExternalAPIError
+
+    def __init__(
+        self,
+        *,
+        client: httpx.AsyncClient | None = None,
+        default_headers: Optional[Dict[str, str]] = None,
+    ) -> None:
+        self._client: httpx.AsyncClient | None = client
+        self._owns_client = client is None
+        self._default_headers = default_headers or {}
+
+    async def __aenter__(self) -> "ExternalAPIAdapter":
+        if not self._client:
+            self._client = httpx.AsyncClient(
+                timeout=httpx.Timeout(self.REQUEST_TIMEOUT),
+                limits=httpx.Limits(max_connections=10, max_keepalive_connections=5),
+            )
+            self._owns_client = True
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - passthrough
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        if self._client and self._owns_client:
+            await self._client.aclose()
+        self._client = None
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        if not self._client:
+            await self.__aenter__()
+        assert self._client is not None
+        return self._client
+
+    def build_headers(self) -> Dict[str, str]:
+        """Return the default headers that should accompany each request."""
+
+        return dict(self._default_headers)
+
+    async def request(
+        self,
+        method: str,
+        endpoint: str,
+        *,
+        params: Dict[str, Any] | None = None,
+        json: Dict[str, Any] | None = None,
+        headers: Dict[str, str] | None = None,
+    ) -> Any:
+        client = await self._get_client()
+        url = urljoin(self.BASE_URL.rstrip("/") + "/", endpoint.lstrip("/"))
+        request_headers = self.build_headers()
+        if headers:
+            request_headers.update(headers)
+
+        for attempt in range(self.MAX_RETRIES):
+            try:
+                response = await client.request(
+                    method,
+                    url,
+                    params=params,
+                    json=json,
+                    headers=request_headers,
+                )
+                response.raise_for_status()
+                return self._decode_response(response)
+            except httpx.HTTPStatusError as exc:
+                raise self.ERROR_CLS(
+                    self.PROVIDER_NAME,
+                    status_code=exc.response.status_code,
+                    detail=self._extract_error_detail(exc.response),
+                    message=f"{self.PROVIDER_NAME} API responded with an error",
+                ) from exc
+            except httpx.RequestError as exc:
+                if attempt < self.MAX_RETRIES - 1:
+                    await asyncio.sleep(self.RETRY_BACKOFF * (2**attempt))
+                    continue
+                raise self.ERROR_CLS(
+                    self.PROVIDER_NAME,
+                    status_code=502,
+                    detail={
+                        "message": f"Failed to communicate with {self.PROVIDER_NAME} API",
+                        "error": str(exc),
+                    },
+                    message=f"Failed to communicate with {self.PROVIDER_NAME} API",
+                ) from exc
+
+    def _decode_response(self, response: httpx.Response) -> Any:
+        try:
+            return response.json()
+        except ValueError as exc:
+            raise self.ERROR_CLS(
+                self.PROVIDER_NAME,
+                status_code=502,
+                detail={
+                    "message": f"Invalid response payload from {self.PROVIDER_NAME} API",
+                    "response_text": response.text,
+                },
+            ) from exc
+
+    def _extract_error_detail(self, response: httpx.Response) -> Any:
+        try:
+            return response.json()
+        except ValueError:
+            return {"message": response.text or "Unknown error"}
+

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,6 +1,6 @@
 """API package exports and provider registry."""
 
-from . import asg, bm_parts, intercars, omega, uniqtrade
+from . import asg, bm_parts, intercars, omega, search, uniqtrade
 
 PROVIDER_REGISTRY = {
     "bm-parts": bm_parts.router,
@@ -8,6 +8,7 @@ PROVIDER_REGISTRY = {
     "asg": asg.router,
     "omega": omega.router,
     "uniqtrade": uniqtrade.router,
+    "search": search.router,
 }
 
 __all__ = ["PROVIDER_REGISTRY"]

--- a/backend/app/api/search.py
+++ b/backend/app/api/search.py
@@ -1,0 +1,115 @@
+"""Aggregated search endpoints fan out to multiple providers."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Awaitable, Callable, Dict
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field, ValidationError
+
+from app.adapters.bm_parts_adapter import BMPartsAdapter, BMPartsAdapterError
+from app.api.auth import get_current_user
+
+router = APIRouter(prefix="/search", tags=["Aggregated Search"])
+
+
+class ProviderSearchOptions(BaseModel):
+    """Container for provider-specific search options."""
+
+    name: str = Field(..., description="Provider key to query")
+    options: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Provider specific options forwarded to the adapter",
+    )
+
+
+class AggregatedSearchRequest(BaseModel):
+    """Request payload for executing a multi-provider product search."""
+
+    query: str = Field(..., min_length=1, description="User supplied search term")
+    providers: list[ProviderSearchOptions] = Field(
+        ..., min_items=1, description="Providers that should participate in the search"
+    )
+
+
+class BMPartsSearchConfig(BaseModel):
+    include_crosses: bool = False
+    include_additional: bool = False
+    filters: Dict[str, Any] = Field(default_factory=dict)
+
+
+async def _search_bm_parts(query: str, options: Dict[str, Any]) -> Any:
+    try:
+        config = BMPartsSearchConfig.model_validate(options or {})
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={"message": "Invalid BM Parts search options", "errors": exc.errors()},
+        ) from exc
+
+    async with BMPartsAdapter() as adapter:
+        return await adapter.search_products_enhanced(
+            query,
+            include_crosses=config.include_crosses,
+            include_additional=config.include_additional,
+            **config.filters,
+        )
+
+
+PROVIDER_HANDLERS: Dict[str, Callable[[str, Dict[str, Any]], Awaitable[Any]]] = {
+    "bm-parts": _search_bm_parts,
+}
+
+
+async def _execute_provider(
+    query: str, provider: ProviderSearchOptions
+) -> Dict[str, Any]:
+    handler = PROVIDER_HANDLERS.get(provider.name)
+    if not handler:
+        return {
+            "provider": provider.name,
+            "success": False,
+            "error": {
+                "status_code": 400,
+                "detail": {"message": f"Unsupported provider '{provider.name}'"},
+            },
+        }
+
+    try:
+        data = await handler(query, provider.options)
+        return {"provider": provider.name, "success": True, "data": data}
+    except BMPartsAdapterError as exc:
+        return {
+            "provider": provider.name,
+            "success": False,
+            "error": {"status_code": exc.status_code, "detail": exc.detail},
+        }
+    except HTTPException as exc:
+        return {
+            "provider": provider.name,
+            "success": False,
+            "error": {"status_code": exc.status_code, "detail": exc.detail},
+        }
+    except Exception as exc:  # pragma: no cover - defensive programming
+        return {
+            "provider": provider.name,
+            "success": False,
+            "error": {
+                "status_code": 500,
+                "detail": {"message": "Unexpected adapter error", "error": str(exc)},
+            },
+        }
+
+
+@router.post("/products")
+async def aggregated_search(
+    request: AggregatedSearchRequest,
+    user: dict = Depends(get_current_user),  # noqa: ARG001 - validation side effect
+):
+    """Perform a multi-provider product search in a single request."""
+
+    tasks = [_execute_provider(request.query, provider) for provider in request.providers]
+    results = await asyncio.gather(*tasks)
+    return {"query": request.query, "results": results}
+

--- a/backend/docs/aggregated-search.md
+++ b/backend/docs/aggregated-search.md
@@ -1,0 +1,76 @@
+# Aggregated Search API
+
+The aggregated search endpoint allows the frontend to fan out a single
+request to multiple providers. Each provider executes its native search
+routine and the backend merges the responses into a consistent payload.
+
+## Endpoint
+
+`POST /search/products`
+
+### Authentication
+
+Every request must include the Supabase bearer token in the `Authorization`
+header. The endpoint reuses the shared `get_current_user` dependency, so no
+additional provider-specific credentials are needed from the client.
+
+### Request Body
+
+```
+{
+  "query": "string",             // Required search phrase.
+  "providers": [
+    {
+      "name": "bm-parts",       // Provider identifier.
+      "options": {
+        "include_crosses": true,
+        "include_additional": false,
+        "filters": { ... }       // Optional BM Parts query parameters.
+      }
+    }
+  ]
+}
+```
+
+### Response Shape
+
+```
+{
+  "query": "string",
+  "results": [
+    {
+      "provider": "bm-parts",
+      "success": true,
+      "data": { ... }            // Raw provider payload when successful.
+    },
+    {
+      "provider": "omega",
+      "success": false,
+      "error": {
+        "status_code": 400,
+        "detail": {
+          "message": "Unsupported provider 'omega'"
+        }
+      }
+    }
+  ]
+}
+```
+
+Each entry in `results` contains the provider key, a `success` flag and either
+`data` (on success) or `error` (on failure). A provider that is not yet
+implemented returns a descriptive error payload without impacting the other
+providers in the batch.
+
+## Adding Providers
+
+1. Implement or reuse an adapter that inherits from `ExternalAPIAdapter`.
+2. Expose an async handler that accepts the `query` string and an `options`
+   dictionary. The handler should return the upstream payload or raise a
+   FastAPI `HTTPException`.
+3. Register the handler in `PROVIDER_HANDLERS` inside
+   `app/api/search.py`. The provider becomes instantly available to the
+   aggregated search route.
+
+This architecture keeps authentication shared while allowing each provider to
+opt into the aggregated search experience with minimal boilerplate.


### PR DESCRIPTION
## Summary
- add a reusable ExternalAPIAdapter base class and refactor BMPartsAdapter to use it
- create an aggregated /search/products endpoint that validates Supabase auth and fans out to registered providers
- document the aggregated search workflow and options in backend/docs

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68cde0dff6e48333b0f4e1098daeb2bf