### PR TITLE
Add credential manager and supplier routing checks

### DIFF
--- a/backend/app/api/unified.py
+++ b/backend/app/api/unified.py
@@ -20,7 +20,7 @@ async def search_space(
 ):
     """Search across enabled suppliers using a BM Parts–like response shape."""
 
-    return await unified_search(request)
+    return await unified_search(request, client_id=user.get("id"))
 
 
 @router.post("/products")
@@ -30,5 +30,5 @@ async def products_space(
 ):
     """Fetch product details from multiple suppliers while tolerating partial failures."""
 
-    return await unified_products(request)
+    return await unified_products(request, client_id=user.get("id"))
 

--- a/backend/app/services/supplier_credentials.py
+++ b/backend/app/services/supplier_credentials.py
@@ -1,0 +1,129 @@
+"""Credential routing and storage for supplier API integrations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Mapping, MutableMapping, Optional
+
+from app.config import (
+    ASG_TOKEN,
+    BM_PARTS_TOKEN,
+    INTERCARS_CLIENT_ID,
+    INTERCARS_CLIENT_SECRET,
+    OMEGA_KEY,
+    UNIQTRADE_EMAIL,
+    UNIQTRADE_FINGERPRINT,
+    UNIQTRADE_PASSWORD,
+)
+
+
+def _clean_payload(payload: Mapping[str, Any]) -> Dict[str, Any]:
+    """Return a shallow copy of ``payload`` without falsy values."""
+
+    return {key: value for key, value in payload.items() if value}
+
+
+@dataclass
+class SupplierCredentialManager:
+    """Simple in-memory registry of client credentials per supplier."""
+
+    default_credentials: Mapping[str, Mapping[str, Any]] = field(default_factory=dict)
+    _store: MutableMapping[str, Dict[str, Dict[str, Any]]] = field(
+        default_factory=dict, init=False
+    )
+
+    REQUIRED_FIELDS: Mapping[str, tuple[tuple[str, ...], ...]] = field(
+        default_factory=lambda: {
+            # BM Parts requires the Authorization token.
+            "bm-parts": (("token",),),
+            # ASG accepts either a bearer token or login/password pair.
+            "asg": (("token",), ("login", "password")),
+            # Omega expects a single API key field.
+            "omega": (("key",),),
+            # UniqTrade requires the full credential set.
+            "uniqtrade": (("email", "password", "fingerprint"),),
+            # InterCars uses OAuth client credentials.
+            "intercars": (("client_id", "client_secret"),),
+        }
+    )
+
+    def _get_store_for_client(self, client_id: str) -> Dict[str, Dict[str, Any]]:
+        return self._store.setdefault(client_id, {})
+
+    def set_credentials(
+        self, client_id: str, supplier: str, credentials: Mapping[str, Any]
+    ) -> None:
+        """Persist credentials for a supplier/client pair."""
+
+        cleaned = _clean_payload(credentials)
+        if not cleaned:
+            return
+        client_store = self._get_store_for_client(client_id)
+        client_store[supplier] = cleaned
+
+    def get_credentials(self, client_id: str, supplier: str) -> Dict[str, Any]:
+        """Return stored credentials or an empty mapping."""
+
+        return dict(self._store.get(client_id, {}).get(supplier, {}))
+
+    def _default_credentials(self, supplier: str) -> Dict[str, Any]:
+        return dict(self.default_credentials.get(supplier, {}))
+
+    def get_effective_credentials(
+        self,
+        supplier: str,
+        *,
+        client_id: Optional[str] = None,
+        overrides: Optional[Mapping[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Merge default credentials, stored client data, and request overrides."""
+
+        result: Dict[str, Any] = {}
+        result.update(self._default_credentials(supplier))
+        if client_id:
+            result.update(self.get_credentials(client_id, supplier))
+        if overrides:
+            result.update(_clean_payload(overrides))
+        if client_id and overrides:
+            self.set_credentials(client_id, supplier, result)
+        return result
+
+    def has_required_credentials(
+        self, supplier: str, credentials: Mapping[str, Any]
+    ) -> bool:
+        """Validate that the credentials contain one of the required field sets."""
+
+        required_sets = self.REQUIRED_FIELDS.get(supplier)
+        if not required_sets:
+            return True
+
+        for field_group in required_sets:
+            if all(credentials.get(field) for field in field_group):
+                return True
+        return False
+
+    def clear_client(self, client_id: str) -> None:
+        """Remove all stored credentials for a client (primarily for tests)."""
+
+        self._store.pop(client_id, None)
+
+
+DEFAULT_CREDENTIAL_MANAGER = SupplierCredentialManager(
+    default_credentials={
+        "bm-parts": {"token": BM_PARTS_TOKEN},
+        "asg": {"token": ASG_TOKEN},
+        "omega": {"key": OMEGA_KEY},
+        "uniqtrade": {
+            "email": UNIQTRADE_EMAIL,
+            "password": UNIQTRADE_PASSWORD,
+            "fingerprint": UNIQTRADE_FINGERPRINT,
+        },
+        "intercars": {
+            "client_id": INTERCARS_CLIENT_ID,
+            "client_secret": INTERCARS_CLIENT_SECRET,
+        },
+    }
+)
+
+
+__all__ = ["SupplierCredentialManager", "DEFAULT_CREDENTIAL_MANAGER"]

--- a/backend/app/services/unified_catalog.py
+++ b/backend/app/services/unified_catalog.py
@@ -1,9 +1,4 @@
-"""Helpers for orchestrating supplier search and product lookups.
-
-This module builds a unified abstraction over the various supplier adapters. It
-fan-outs requests, normalises payloads to a BM Parts–like shape, and
-coalesces partial failures into metadata instead of raising.
-"""
+"""Unified abstraction over supplier adapters with credential-aware routing."""
 
 from __future__ import annotations
 
@@ -18,6 +13,10 @@ from app.adapters.asg_adapter import ASGAdapter, ASGAPIError
 from app.adapters.bm_parts_adapter import BMPartsAdapter, BMPartsAdapterError
 from app.adapters.omega_adapter import OmegaAdapter, OmegaAPIError
 from app.adapters.uniqtrade_adapter import UniqTradeAPIError, UniqTradeAdapter
+from app.services.supplier_credentials import (
+    DEFAULT_CREDENTIAL_MANAGER,
+    SupplierCredentialManager,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -262,11 +261,29 @@ SEARCH_HANDLERS: dict[str, Callable[[str, Dict[str, Any]], Awaitable[Any]]] = {
 }
 
 
-async def unified_search(request: UnifiedSearchRequest) -> Dict[str, Any]:
-    """Execute a cross-supplier product search."""
+def _prepare_supplier_options(
+    supplier: str,
+    *,
+    client_id: str | None,
+    manager: SupplierCredentialManager,
+    request_options: Dict[str, Any],
+) -> Dict[str, Any]:
+    return manager.get_effective_credentials(
+        supplier, client_id=client_id, overrides=request_options
+    )
+
+
+async def unified_search(
+    request: UnifiedSearchRequest,
+    *,
+    client_id: str | None = None,
+    credential_manager: SupplierCredentialManager = DEFAULT_CREDENTIAL_MANAGER,
+) -> Dict[str, Any]:
+    """Execute a cross-supplier product search with credential-aware routing."""
 
     requested_suppliers = request.suppliers or SUPPORTED_SUPPLIERS
     tasks: list[Awaitable[SupplierResult]] = []
+    skipped: list[str] = []
 
     for supplier in requested_suppliers:
         handler = SEARCH_HANDLERS.get(supplier)
@@ -284,8 +301,22 @@ async def unified_search(request: UnifiedSearchRequest) -> Dict[str, Any]:
             )
             continue
 
-        options = request.supplier_options.get(supplier, {})
-        tasks.append(_call_handler(supplier, lambda h=handler, o=options: h(request.query, o)))
+        options = _prepare_supplier_options(
+            supplier,
+            client_id=client_id,
+            manager=credential_manager,
+            request_options=request.supplier_options.get(supplier, {}),
+        )
+
+        if not credential_manager.has_required_credentials(supplier, options):
+            skipped.append(supplier)
+            continue
+
+        tasks.append(
+            _call_handler(
+                supplier, lambda h=handler, o=options: h(request.query, o)
+            )
+        )
 
     results = await asyncio.gather(*tasks)
     products = [product for result in results for product in result.products]
@@ -302,6 +333,7 @@ async def unified_search(request: UnifiedSearchRequest) -> Dict[str, Any]:
             "requested_suppliers": requested_suppliers,
             "failed_suppliers": failed,
             "partial_failure": bool(failed),
+            "skipped_suppliers": skipped,
         },
     }
 
@@ -345,10 +377,16 @@ PRODUCT_HANDLERS: dict[str, Callable[[str, Dict[str, Any]], Awaitable[Any]]] = {
 }
 
 
-async def unified_products(request: UnifiedProductsRequest) -> Dict[str, Any]:
-    """Fetch product details from multiple suppliers concurrently."""
+async def unified_products(
+    request: UnifiedProductsRequest,
+    *,
+    client_id: str | None = None,
+    credential_manager: SupplierCredentialManager = DEFAULT_CREDENTIAL_MANAGER,
+) -> Dict[str, Any]:
+    """Fetch product details while honouring per-client credential availability."""
 
     tasks: list[Awaitable[SupplierResult]] = []
+    skipped: list[str] = []
 
     for product in request.products:
         handler = PRODUCT_HANDLERS.get(product.supplier)
@@ -366,10 +404,23 @@ async def unified_products(request: UnifiedProductsRequest) -> Dict[str, Any]:
             )
             continue
 
+        options = _prepare_supplier_options(
+            product.supplier,
+            client_id=client_id,
+            manager=credential_manager,
+            request_options=product.options,
+        )
+
+        if not credential_manager.has_required_credentials(product.supplier, options):
+            skipped.append(product.supplier)
+            continue
+
         tasks.append(
             _call_handler(
                 product.supplier,
-                lambda h=handler, p=product: h(p.product_id, p.options),
+                lambda h=handler, pid=product.product_id, o=options: h(
+                    pid, o
+                ),
             )
         )
 
@@ -386,6 +437,7 @@ async def unified_products(request: UnifiedProductsRequest) -> Dict[str, Any]:
         "meta": {
             "failed_suppliers": failed,
             "partial_failure": bool(failed),
+            "skipped_suppliers": skipped,
         },
     }
 

--- a/backend/tests/test_supplier_credentials.py
+++ b/backend/tests/test_supplier_credentials.py
@@ -1,0 +1,77 @@
+import pytest
+
+from app.services import unified_catalog
+from app.services.supplier_credentials import SupplierCredentialManager
+from app.services.unified_catalog import UnifiedSearchRequest, unified_search
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def test_manager_stores_credentials_per_client():
+    manager = SupplierCredentialManager()
+    manager.set_credentials("client-a", "omega", {"key": "123"})
+    manager.set_credentials("client-b", "omega", {"key": "456"})
+
+    assert manager.get_credentials("client-a", "omega") == {"key": "123"}
+    assert manager.get_credentials("client-b", "omega") == {"key": "456"}
+
+
+@pytest.mark.parametrize(
+    "supplier, credentials, expected",
+    [
+        ("bm-parts", {}, False),
+        ("bm-parts", {"token": "t"}, True),
+        ("asg", {"token": "t"}, True),
+        ("asg", {"login": "l", "password": "p"}, True),
+        ("asg", {"login": "l"}, False),
+        (
+            "uniqtrade",
+            {"email": "e", "password": "p", "fingerprint": "f"},
+            True,
+        ),
+        ("uniqtrade", {"email": "e", "password": "p"}, False),
+    ],
+)
+def test_required_credentials_validation(supplier, credentials, expected):
+    manager = SupplierCredentialManager()
+    assert manager.has_required_credentials(supplier, credentials) is expected
+
+
+def test_effective_credentials_merge_and_persist():
+    manager = SupplierCredentialManager(
+        default_credentials={"omega": {"key": "default"}}
+    )
+
+    merged = manager.get_effective_credentials(
+        "omega", client_id="client-1", overrides={"key": "override"}
+    )
+
+    # Override wins over default and is persisted for the client
+    assert merged == {"key": "override"}
+    assert manager.get_credentials("client-1", "omega") == {"key": "override"}
+
+    # Subsequent calls can read from the stored value
+    reused = manager.get_effective_credentials("omega", client_id="client-1")
+    assert reused == {"key": "override"}
+
+
+@pytest.mark.anyio
+async def test_unified_search_skips_unconfigured_suppliers(monkeypatch):
+    async def fake_handler(query, options):  # pragma: no cover - not executed
+        return {"products": []}
+
+    monkeypatch.setitem(unified_catalog.SEARCH_HANDLERS, "omega", fake_handler)
+
+    manager = SupplierCredentialManager()
+    request = UnifiedSearchRequest(query="q", suppliers=["omega"])
+
+    response = await unified_search(
+        request, client_id="client-x", credential_manager=manager
+    )
+
+    assert response["products"] == []
+    assert response["meta"]["skipped_suppliers"] == ["omega"]
+

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -44,10 +44,13 @@ Backend Packages
     extracts login information from headers or bodies.
 
 ``app/services``
-    Cross-cutting helpers that are reused by multiple adapters. Currently this
-    hosts the token cache abstraction shared by InterCars routes and the
-    unified catalog service that fans out requests to all enabled suppliers and
-    returns BM Parts–shaped responses with partial failure metadata.
+    Cross-cutting helpers that are reused by multiple adapters. This includes
+    the credential manager that merges default environment tokens with
+    per-client overrides, the token cache abstraction shared by InterCars
+    routes, and the unified catalog service that fans out requests to all
+    enabled suppliers and returns BM Parts–shaped responses with partial
+    failure metadata. Suppliers without valid credentials for the authenticated
+    client are automatically skipped to avoid blocking other providers.
 
 ``app/config.py``
     Centralises configuration read from environment variables (tokens, API

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -15,23 +15,26 @@ The backend targets Python 3.11. Install dependencies and run the service with:
 Environment Variables
 ---------------------
 
-The adapters expect the following environment variables to be populated before
-startup:
+Supplier adapters require credentials during startup or when handling requests.
+Populate the following variables in your ``.env`` file:
 
 ``BM_PARTS_TOKEN``
-    Static token string used to authenticate against the BM Parts API.
+    Static token string used to authenticate against the BM Parts API. Used as
+    the default credential for clients that do not provide their own token.
+
+``ASG_TOKEN``
+    Default ASG bearer token. Requests can override this by supplying
+    ``login``/``password`` or a different ``token`` via ``supplier_options``.
+
+``OMEGA_KEY``
+    API key for Omega. Stored as the default ``key`` in unified calls.
+
+``UNIQTRADE_EMAIL`` / ``UNIQTRADE_PASSWORD`` / ``UNIQTRADE_FINGERPRINT``
+    Required credential trio for UniqTrade requests. Stored as defaults and can
+    be overridden per client.
 
 ``INTERCARS_CLIENT_ID`` / ``INTERCARS_CLIENT_SECRET``
     OAuth client credentials for the InterCars integration.
-
-``ASG_TOKEN``
-    Default ASG API token used for bootstrap flows.
-
-``OMEGA_API_URL`` and ``OMEGA_API_KEY``
-    Base URL and API key for Omega requests.
-
-``UNIQTRADE_API_KEY``
-    Credential required by the UniqTrade client.
 
 
 Running Tests

--- a/docs/frontend_integration.rst
+++ b/docs/frontend_integration.rst
@@ -10,6 +10,29 @@ Authentication
 All routes require the Supabase JWT in the ``Authorization`` header:
 ``Authorization: Bearer <supabase-jwt>``.
 
+Credential handling
+-------------------
+
+Supplier adapters need API credentials to execute requests. The unified layer
+combines three sources:
+
+- Defaults from environment variables.
+- Credentials previously provided by the authenticated client.
+- Per-request ``supplier_options``.
+
+When overrides are present they are stored for that client, so subsequent calls
+do not need to repeat the secrets. Suppliers missing the required fields are
+skipped and listed under ``meta.skipped_suppliers``.
+
+Required fields per supplier
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- ``bm-parts``: ``token``
+- ``asg``: either ``token`` or a ``login``/``password`` pair
+- ``omega``: ``key``
+- ``uniqtrade``: ``email``, ``password``, and ``fingerprint``
+- ``intercars``: ``client_id`` and ``client_secret``
+
 Search flow (``POST /space/search``)
 ------------------------------------
 
@@ -26,7 +49,8 @@ Search flow (``POST /space/search``)
 - ``products``: list of entries with ``part`` (BM Parts-like fields), ``rests``
   availability, ``supplier`` slug, and ``raw`` provider payload.
 - ``meta``: includes ``requested_suppliers``, ``failed_suppliers`` with
-  ``status_code``/``detail``, and ``partial_failure`` boolean.
+  ``status_code``/``detail``, ``skipped_suppliers`` for missing credentials, and
+  ``partial_failure`` boolean.
 
 **Fetch example**
 
@@ -59,8 +83,9 @@ Product details flow (``POST /space/products``)
 
 - ``products``: BM Parts-shaped product entries (``part``, ``rests``,
   ``supplier``, ``raw``)
-- ``meta``: ``failed_suppliers`` array and ``partial_failure`` flag. Successful
-  suppliers still return results even if others fail.
+- ``meta``: ``failed_suppliers`` array, ``skipped_suppliers`` for missing
+  credentials, and ``partial_failure`` flag. Successful suppliers still return
+  results even if others fail.
 
 **Fetch example**
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,7 @@ Check4Parts Technical Documentation
    :caption: Contents
 
    architecture
+   supplier_credentials
    backend_modules
    api_reference
    development

--- a/docs/supplier_credentials.rst
+++ b/docs/supplier_credentials.rst
@@ -1,0 +1,41 @@
+Supplier credential routing
+===========================
+
+Supplier adapters require different authentication inputs. The backend consolidates
+credential handling via ``SupplierCredentialManager`` in
+``app.services.supplier_credentials``. It merges three sources in order:
+
+1. Default credentials from environment variables (see :doc:`development`).
+2. Values previously stored for the current authenticated client.
+3. Per-request overrides sent inside ``supplier_options``.
+
+When a client supplies overrides, the merged values are persisted for that client
+so future calls do not need to repeat the secrets.
+
+Required credential fields
+--------------------------
+
+The routing layer validates that at least one acceptable credential set is
+present per supplier:
+
+- ``bm-parts``: ``token``
+- ``asg``: either ``token`` or a ``login``/``password`` pair
+- ``omega``: ``key``
+- ``uniqtrade``: ``email``, ``password``, and ``fingerprint``
+- ``intercars``: ``client_id`` and ``client_secret`` (used by InterCars-specific
+  routes)
+
+If a supplier is missing its required fields after merging defaults and stored
+values, the unified catalog services skip it and record the slug under
+``meta.skipped_suppliers``.
+
+Client-facing behaviour
+-----------------------
+
+- Requests against ``/space/search`` or ``/space/products`` only fan out to
+  suppliers with valid credentials for the authenticated client.
+- Missing or incomplete credentials never block other suppliers; they are simply
+  skipped.
+- Invalid or failing suppliers are surfaced separately in
+  ``meta.failed_suppliers`` with status codes and details, so the frontend can
+  inform the user without losing successful data from other providers.


### PR DESCRIPTION
## Summary
- add a reusable credential manager that stores per-client supplier credentials with default fallbacks
- update unified catalog routing to require valid credentials and skip unconfigured suppliers
- document behaviour with tests covering credential validation and skipping logic

## Testing
- `pytest backend/tests/test_supplier_credentials.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927f15d78b883338d11de8791bf8e34)